### PR TITLE
Adds the option to communicate over SSL

### DIFF
--- a/Crm/Company.php
+++ b/Crm/Company.php
@@ -670,11 +670,6 @@ class Company
         if ($this->getTags()) {
             $return['add_tag_by_string'] = implode(',', $this->getTags());
         }
-        if ($this->getCustomFields()) {
-            foreach($this->getCustomFields() as $fieldID => $fieldValue) {
-                $return['custom_field_' . $fieldID] = $fieldValue;
-            }
-        }
 
         return $return;
     }

--- a/Crm/Contact.php
+++ b/Crm/Contact.php
@@ -656,11 +656,6 @@ class Contact
         if ($this->getTags()) {
             $return['add_tag_by_string'] = implode(',', $this->getTags());
         }
-        if ($this->getCustomFields()) {
-            foreach($this->getCustomFields() as $fieldID => $fieldValue) {
-                $return['custom_field_' . $fieldID] = $fieldValue;
-            }
-        }
         return $return;
     }
 }


### PR DESCRIPTION
When constructing the teamleader wrapper you can now set the option to use SSL.
SSL is disabled by default for backwards compatibility
