### PR TITLE
Bugfix: The api doesn't return deal id, so we'll fake it.

### DIFF
--- a/Teamleader.php
+++ b/Teamleader.php
@@ -674,6 +674,14 @@ class Teamleader
             throw new Exception($rawData);
         }
 
+        // This is a bugfix: The api doesn't return the deal's id when we ask for a specific deal using this endpoint.
+        // To be able to return a complete Deal Entity, it needs to have its id set.
+        // We will just fake the id by inserting it ourselves. This if block may be removed when the api returns an id,
+        // and everything should keep working.
+        if (!isset($rawData['id'])) {
+            $rawData['id'] = (int) $id;
+        }
+
         return Deal::initializeWithRawData($rawData);
     }
 


### PR DESCRIPTION
This is a bugfix: The api doesn't return the deal's id when we ask
for a specific deal using this endpoint. To be able to return a
complete Deal Entity, it needs to have its id set. We will just
fake the id by inserting it ourselves. This if block may be removed
when the api returns an id, and everything should keep working.
