### PR TITLE
Zipcode Capital letter fix

### DIFF
--- a/Crm/Company.php
+++ b/Crm/Company.php
@@ -473,7 +473,7 @@ class Company
     /**
      * @param string $zipCode
      */
-    public function setZipCode($zipCode)
+    public function setZipcode($zipCode)
     {
         $this->zipCode = $zipCode;
     }
@@ -481,7 +481,7 @@ class Company
     /**
      * @return string
      */
-    public function getZipCode()
+    public function getZipcode()
     {
         return $this->zipCode;
     }


### PR DESCRIPTION
The Zipcode wasn't being returned correctly because of a capital C on code.