### PR TITLE
Fix warning implode on linked company ids string

### DIFF
--- a/Crm/Contact.php
+++ b/Crm/Contact.php
@@ -622,7 +622,7 @@ class Contact
             $return['dob'] = $this->getDob();
         }
         if ($this->getLinkedCompanyIds()) {
-            $return['linked_company_ids'] = implode(',', $this->getLinkedCompanyIds());
+            $return['linked_company_ids'] = implode(',', (array) $this->getLinkedCompanyIds());
         }
 
         return $return;


### PR DESCRIPTION
cast the response of the getter to an array because it sometimes is a string

When doing an implode on a string a warning is generated, this fixed that