### PR TITLE
Fix download of PDF

### DIFF
--- a/Teamleader.php
+++ b/Teamleader.php
@@ -259,6 +259,10 @@ class Teamleader
             }
         }
 
+        if ($endPoint === 'downloadInvoicePDF.php') {
+            return $response;
+        }
+
         // we expect JSON so decode it
         $json = @json_decode($response, true);
 


### PR DESCRIPTION
When trying to download a PDF, the API does not return a JSON response.
Instead of trying to decode the JSON, we return the PDF content directly.