### PR TITLE
Add rate limit reached exception for http 505 status code

### DIFF
--- a/Teamleader.php
+++ b/Teamleader.php
@@ -261,6 +261,11 @@ class Teamleader
             }
         }
 
+        // in case we received an error 505 API rate limit reached an exception should be thrown
+        if ($headers['http_code'] == 505) {
+            throw new Exception('Teamleader '.$endPoint.' API returned statuscode 505 API rate limit reached.');
+        }
+
         if ($endPoint === 'downloadInvoicePDF.php') {
             return $response;
         }


### PR DESCRIPTION
Teamleader uses HTTP status code 505 instead of 429 to indicate too
many requests. Check out the docs at http://apidocs.teamleader.eu/
for current Teamleader API rate limiting policy.