### PR TITLE
Fix possible infinite loop for crmGetAllCustomers

### DIFF
--- a/Teamleader.php
+++ b/Teamleader.php
@@ -747,7 +747,11 @@ class Teamleader
         $customers['contacts'] = array();
         $i = 0;
         while ($i == 0 || (sizeof($customers['contacts']) != 0 && sizeof($customers['contacts']) % 100 == 0)) {
-            foreach ($this->crmGetContacts(100, $i) as $contact) {
+            $contacts = $this->crmGetContacts(100, $i);
+            if (empty($contacts)) {
+                break;
+            }
+            foreach ($contacts as $contact) {
                 $customers['contacts'][$contact->getId()] = $contact;
             }
             $i++;
@@ -756,7 +760,11 @@ class Teamleader
         $customers['companies'] = array();
         $i = 0;
         while ($i == 0 || (sizeof($customers['companies']) != 0 && sizeof($customers['companies']) % 100 == 0)) {
-            foreach ($this->crmGetCompanies(100, $i) as $company) {
+            $companies = $this->crmGetCompanies(100, $i);
+            if (empty($companies)) {
+                break;
+            }
+            foreach ($companies as $company) {
                 $customers['companies'][$company->getId()] = $company;
             }
             $i++;


### PR DESCRIPTION
The crmGetAllCustomers method loads all contacts & all companies from
the Teamleader API in batches of 100 items each. There was just one
small problem that could cause an infinite loop.

The while loops checks if the array is a multiple of 100. If so, the
next page is fetched and so on. But if you had exactly 100 contacts or
companies, or a multiple of 100, every next page returns 0 items. The
result array is always a multiple of 100 since there are no more items
added, and BAM, infinite loop.

This commit adds a check for an empty result set. If so, the while loop
is terminated and the results are returned.