### PR TITLE
Include custom fields in search actions

### DIFF
--- a/Invoices/Invoice.php
+++ b/Invoices/Invoice.php
@@ -124,6 +124,11 @@ class Invoice
     private $comments;
 
     /**
+     * @var array
+     */
+    private $customFields;
+
+    /**
      * @return int
      */
     public function getId()
@@ -490,6 +495,34 @@ class Invoice
     }
 
     /**
+     * Set a single custom field
+     *
+     * @param string $id
+     * @param mixed  $value
+     */
+    public function setCustomField($id, $value)
+    {
+        $this->customFields[$id] = $value;
+    }
+
+    /**
+     * @param array $customFields
+     */
+    public function setCustomFields($customFields)
+    {
+        $this->customFields = $customFields;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCustomFields()
+    {
+        return $this->customFields;
+    }
+
+
+    /**
      * Initialize an Invoice with raw data we got from the API
      *
      * @param  array        $data
@@ -502,6 +535,11 @@ class Invoice
 
         foreach ($data as $key => $value) {
             switch ($key) {
+                case substr($key, 0, 3) == 'cf_':
+                    $chunks = explode('_', $key);
+                    $id = end($chunks);
+                    $invoice->setCustomField($id, $value);
+                    break;
 
                 case 'date_paid':
                     if ($value != -1) {

--- a/Teamleader.php
+++ b/Teamleader.php
@@ -849,10 +849,11 @@ class Teamleader
      * @param string $searchBy  A search string. Teamleader will try to search deals matching this string.
      * @param int    $segmentId Teamleader will only return deals in this segment.
      * @param int    $phaseId   Teamleader will return only deals that are in this phase right now.
+     * @param array  $customFields An array containig the custom field id's to be included in the result
      *
      * @return Deal
      */
-    public function dealsGetDeals($amount = 100, $page = 0, $searchBy = null, $segmentId = null, $phaseId = null)
+    public function dealsGetDeals($amount = 100, $page = 0, $searchBy = null, $segmentId = null, $phaseId = null, array $customFields = null)
     {
         $fields = array();
         $fields['amount'] = (int) $amount;
@@ -866,6 +867,9 @@ class Teamleader
         }
         if ($phaseId !== null) {
             $fields['filter_by_phase_id'] = (int) $phaseId;
+        }
+        if ($customFields !== null) {
+            $fields['selected_customfields'] = implode(',', $customFields);
         }
 
         $rawData = $this->doCall('getDeals.php', $fields);

--- a/Teamleader.php
+++ b/Teamleader.php
@@ -947,9 +947,12 @@ class Teamleader
      * @param int $dateTo
      * @param Contact|Company|null $contactOrCompany
      * @param bool $deepSearch
+     * @param array $customFields An array containig the custom field
+     *                                   id's to be included in the result
+     *
      * @return Invoice[]
      */
-    public function invoicesGetInvoices($dateFrom, $dateTo, $contactOrCompany = null, $deepSearch = false)
+    public function invoicesGetInvoices($dateFrom, $dateTo, $contactOrCompany = null, $deepSearch = false, array $customFields = null)
     {
         $fields = array();
         $fields['date_from'] = date('d/m/Y', $dateFrom);
@@ -973,6 +976,9 @@ class Teamleader
 
         if ($deepSearch) {
             $fields['deep_search'] = 1;
+        }
+        if ($customFields !== null) {
+            $fields['selected_customfields'] = implode(',', $customFields);
         }
 
         $rawData = $this->doCall('getInvoices.php', $fields);

--- a/Teamleader.php
+++ b/Teamleader.php
@@ -452,9 +452,11 @@ class Teamleader
      * @param int|null $modifiedSince Teamleader will only return contacts
      *                                   that have been added or modified
      *                                   since that timestamp.
+     * @param array|null $customFields An array containig the custom field
+     *                                   id's to be included in the result
      * @return Contact[]
      */
-    public function crmGetContacts($amount = 100, $page = 0, $searchBy = null, $modifiedSince = null)
+    public function crmGetContacts($amount = 100, $page = 0, $searchBy = null, $modifiedSince = null, array $customFields = null)
     {
         $fields = array();
         $fields['amount'] = (int) $amount;
@@ -465,6 +467,9 @@ class Teamleader
         }
         if ($modifiedSince !== null) {
             $fields['modifiedsince'] = (int) $modifiedSince;
+        }
+        if ($customFields !== null) {
+            $fields['selected_customfields'] = implode(',', $customFields);
         }
 
         $rawData = $this->doCall('getContacts.php', $fields);

--- a/Teamleader.php
+++ b/Teamleader.php
@@ -851,7 +851,7 @@ class Teamleader
      * @param int    $phaseId   Teamleader will return only deals that are in this phase right now.
      * @param array  $customFields An array containig the custom field id's to be included in the result
      *
-     * @return Deal
+     * @return Deal[]
      */
     public function dealsGetDeals($amount = 100, $page = 0, $searchBy = null, $segmentId = null, $phaseId = null, array $customFields = null)
     {

--- a/Teamleader.php
+++ b/Teamleader.php
@@ -668,9 +668,11 @@ class Teamleader
      *                                   that have been added or modified
      *                                   since that timestamp.
      * @param string|null $filterByTag Teamleader will only return companies with this tag.
+     * @param array|null $customFields An array containig the custom field
+     *                                   id's to be included in the result
      * @return Company[]
      */
-    public function crmGetCompanies($amount = 100, $page = 0, $searchBy = null, $modifiedSince = null, $filterByTag = null)
+    public function crmGetCompanies($amount = 100, $page = 0, $searchBy = null, $modifiedSince = null, $filterByTag = null, array $customFields = null)
     {
         $fields = array();
         $fields['amount'] = (int) $amount;
@@ -684,6 +686,9 @@ class Teamleader
         }
         if ($filterByTag !== null) {
             $fields['filter_by_tag'] = (string) $filterByTag;
+        }
+        if ($customFields !== null) {
+            $fields['selected_customfields'] = implode(',', $customFields);
         }
 
         $rawData = $this->doCall('getCompanies.php', $fields);


### PR DESCRIPTION
In some of the search actions in the Teamleader API you can define which custom fields to include in the search result. This wasn't implemented in this api wrapper yet.

Updated modules:
* Contact
* Company
* Deal
* Invoice (entity class has been updated too in order to allow storing custom fields)


Some method declarations became pretty long, and since I didn't know if you liked them on one line or split into multiple lines, I kept all arguments on one line.

