### PR TITLE
Include custom fields for products

### DIFF
--- a/Teamleader.php
+++ b/Teamleader.php
@@ -786,7 +786,7 @@ class Teamleader
     public function crmGetAllCustomFields()
     {
         $custom_fields = array();
-        $types = array('contact', 'company', 'sale', 'project', 'invoice', 'ticket', 'milestone', 'todo');
+        $types = array('contact', 'company', 'sale', 'project', 'invoice', 'ticket', 'milestone', 'todo', 'product');
 
         foreach ($types as $for) {
             $custom_fields[$for] = $this->crmGetCustomField($for);


### PR DESCRIPTION
Getting all the custom fields did not fetch the custom fields for products (product custom fields aren't explained in the [API docs](http://apidocs.teamleader.be/customfields.php) but they still can be fetched).