### PR TITLE
Add updated api v1 endpoint

### DIFF
--- a/Teamleader.php
+++ b/Teamleader.php
@@ -32,7 +32,7 @@ class Teamleader
     const DEBUG = false;
 
     // base endpoint
-    const API_URL = 'https://www.teamleader.be/api';
+    const API_URL = 'https://app.teamleader.eu/api';
 
     // port
     const API_PORT = 443;


### PR DESCRIPTION
The old, www.teamleader.be, api endpoint is [soon to be deprecated].(https://blog.teamleader.eu/product/teamleader-terminating-api)