### PR TITLE
Update Company.php

### DIFF
--- a/Crm/Company.php
+++ b/Crm/Company.php
@@ -684,18 +684,16 @@ class Company
 
                 default:
                     // Ignore empty values
-                    if ($value == '') {
-                        continue;
-                    }
-
-                    $methodName = 'set' . str_replace(' ', '', ucwords(str_replace('_', ' ', $key)));
-                    if (!method_exists(__CLASS__, $methodName)) {
-                        if (Teamleader::DEBUG) {
-                            var_dump($key, $value);
-                            throw new Exception('Unknown method (' . $methodName . ')');
+                    if ($value != '') {
+                        $methodName = 'set' . str_replace(' ', '', ucwords(str_replace('_', ' ', $key)));
+                        if (!method_exists(__CLASS__, $methodName)) {
+                            if (Teamleader::DEBUG) {
+                                var_dump($key, $value);
+                                throw new Exception('Unknown method (' . $methodName . ')');
+                            }
+                        } else {
+                            call_user_func(array($item, $methodName), $value);
                         }
-                    } else {
-                        call_user_func(array($item, $methodName), $value);
                     }
             }
         }


### PR DESCRIPTION
Fix php 7.4 error
[2020-04-09 19:14:13] testing.ERROR: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? {"userId":"744cf977-d986-4e78-877f-cc2d50a41134","exception":"[object] (ErrorException(code: 0): \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? at /var/www/wingman-backend/vendor/sumocoders/teamleader/SumoCoders/Teamleader/Crm/Company.php:688)