### PR TITLE
Adjust teamleader.eu url to focus.teamleader.eu

### DIFF
--- a/Teamleader.php
+++ b/Teamleader.php
@@ -32,7 +32,7 @@ class Teamleader
     const DEBUG = false;
 
     // base endpoint
-    const API_URL = 'https://app.teamleader.eu/api';
+    const API_URL = 'https://focus.teamleader.eu/api';
 
     // port
     const API_PORT = 443;


### PR DESCRIPTION
The Teamleader application has been renamed to Teamleader Focus, more info about this can be found [here](https://www.teamleader.eu/blog/new-names-teamleader-focus-orbit). This product name change also means that the application, api, marketplace, etc. have a new home under [focus.teamleader.eu](https://focus.teamleader.eu).

This PR changes the Teamleader URLs in this repo to point to [focus.teamleader.eu](https://focus.teamleader.eu). The switch to these new URLs isn't urgent though, the old URLs will remain available for some time.