### PR TITLE
curl_errno fix

### DIFF
--- a/Teamleader.php
+++ b/Teamleader.php
@@ -247,7 +247,7 @@ class Teamleader
         $errorMessage = curl_error($curl);
 
         // error?
-        if ($errorNumber != '') {
+        if ($errorNumber != 0) {
             throw new Exception($errorMessage, $errorNumber);
         }
 


### PR DESCRIPTION
https://www.php.net/manual/en/function.curl-errno.php

Curl errno returns the error number as int, 0  => 'OK', currently this throws an Exception